### PR TITLE
Change HTTP status from 403 to 429

### DIFF
--- a/mod_evasive.c
+++ b/mod_evasive.c
@@ -149,7 +149,7 @@ static int check_access(request_rec *r)
       if (n != NULL && t-n->timestamp<blocking_period) {
  
         /* If the IP is on "hold", make it wait longer in 403 land */
-        ret = FORBIDDEN;
+        ret = TOO_MANY_REQUESTS;
         n->timestamp = time(NULL);
 
       /* Not on hold, check hit stats */
@@ -162,7 +162,7 @@ static int check_access(request_rec *r)
               
               /* If URI is being hit too much, add to "hold" list and 403 */
               if (t - n->timestamp < uri_interval && n->count >= uri_count) {
-                  ret = FORBIDDEN;
+                  ret = TOO_MANY_REQUESTS;
                   snprintf(hash_key, 2048, "%ld", address);
                   ntt_insert(hit_list, hash_key, time(NULL));
               } else {
@@ -187,7 +187,7 @@ static int check_access(request_rec *r)
 
           /* If page resource is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<page_interval && n->count>=page_count) {
-            ret = FORBIDDEN;
+            ret = TOO_MANY_REQUESTS;
             snprintf(hash_key, 2048, "%ld", address);
             ntt_insert(hit_list, hash_key, time(NULL));
           } else {
@@ -212,7 +212,7 @@ static int check_access(request_rec *r)
 
           /* If site is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<site_interval && n->count>=site_count) {
-            ret = FORBIDDEN;
+            ret = TOO_MANY_REQUESTS;
             snprintf(hash_key, 2048, "%ld", address);
             ntt_insert(hit_list, hash_key, time(NULL));
           } else {
@@ -230,7 +230,7 @@ static int check_access(request_rec *r)
       }
 
       /* Perform email notification and system functions */
-      if (ret == FORBIDDEN) {
+      if (ret == TOO_MANY_REQUESTS) {
         char filename[1024];
         struct stat s;
         FILE *file;
@@ -265,13 +265,13 @@ static int check_access(request_rec *r)
 
         } /* if (temp file does not exist) */
 
-      } /* if (ret == FORBIDDEN) */
+      } /* if (ret == TOO_MANY_REQUESTS) */
 
     } /* if (r->prev == NULL && r->main == NULL && hit_list != NULL) */
 
     /* END Evasive Maneuvers Code */
 
-    if (ret == FORBIDDEN
+    if (ret == TOO_MANY_REQUESTS
 	&& (ap_satisfies(r) != SATISFY_ANY || !ap_some_auth_required(r))) {
 	ap_log_rerror(APLOG_MARK, APLOG_NOERRNO|APLOG_ERR, r,
 		  "client denied by server configuration: %s",

--- a/mod_evasive20.c
+++ b/mod_evasive20.c
@@ -154,7 +154,7 @@ static int access_checker(request_rec *r)
       if (n != NULL && t-n->timestamp<blocking_period) {
  
         /* If the IP is on "hold", make it wait longer in 403 land */
-        ret = HTTP_FORBIDDEN;
+        ret = HTTP_TOO_MANY_REQUESTS;
         n->timestamp = time(NULL);
 
       /* Not on hold, check hit stats */
@@ -167,7 +167,7 @@ static int access_checker(request_rec *r)
               
               /* If URI is being hit too much, add to "hold" list and 403 */
               if (t - n->timestamp < uri_interval && n->count >= uri_count) {
-                  ret = HTTP_FORBIDDEN;
+                  ret = HTTP_TOO_MANY_REQUESTS;
                   ntt_insert(hit_list, r->connection->remote_ip, time(NULL));
               } else {
                   
@@ -191,7 +191,7 @@ static int access_checker(request_rec *r)
 
           /* If page resource is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<page_interval && n->count>=page_count) {
-            ret = HTTP_FORBIDDEN;
+            ret = HTTP_TOO_MANY_REQUESTS;
             ntt_insert(hit_list, r->connection->remote_ip, time(NULL));
           } else {
 
@@ -215,7 +215,7 @@ static int access_checker(request_rec *r)
 
           /* If site is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<site_interval && n->count>=site_count) {
-            ret = HTTP_FORBIDDEN;
+            ret = HTTP_TOO_MANY_REQUESTS;
             ntt_insert(hit_list, r->connection->remote_ip, time(NULL));
           } else {
 
@@ -232,7 +232,7 @@ static int access_checker(request_rec *r)
       }
 
       /* Perform email notification and system functions */
-      if (ret == HTTP_FORBIDDEN) {
+      if (ret == HTTP_TOO_MANY_REQUESTS) {
         char filename[1024];
         struct stat s;
         FILE *file;
@@ -267,13 +267,13 @@ static int access_checker(request_rec *r)
 
         } /* if (temp file does not exist) */
 
-      } /* if (ret == HTTP_FORBIDDEN) */
+      } /* if (ret == HTTP_TOO_MANY_REQUESTS) */
 
     } /* if (r->prev == NULL && r->main == NULL && hit_list != NULL) */
 
     /* END DoS Evasive Maneuvers Code */
 
-    if (ret == HTTP_FORBIDDEN
+    if (ret == HTTP_TOO_MANY_REQUESTS
 	&& (ap_satisfies(r) != SATISFY_ANY || !ap_some_auth_required(r))) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
             "client denied by server configuration: %s",

--- a/mod_evasive24.c
+++ b/mod_evasive24.c
@@ -164,7 +164,7 @@ static int access_checker(request_rec *r)
       if (n != NULL && t-n->timestamp<blocking_period) {
  
         /* If the IP is on "hold", make it wait longer in 403 land */
-        ret = HTTP_FORBIDDEN;
+        ret = HTTP_TOO_MANY_REQUESTS;
         n->timestamp = time(NULL);
         reason = n->reason;
 
@@ -179,7 +179,7 @@ static int access_checker(request_rec *r)
               /* If URI is being hit too much, add to "hold" list and 403 */
               if (t - n->timestamp < uri_interval && n->count >= uri_count) {
                   reason = 1;
-                  ret = HTTP_FORBIDDEN;
+                  ret = HTTP_TOO_MANY_REQUESTS;
                   ntt_insert(hit_list, r->connection->client_ip, time(NULL), reason);
               } else {
                   
@@ -204,7 +204,7 @@ static int access_checker(request_rec *r)
           /* If page resource is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<page_interval && n->count>=page_count) {
             reason = 2;
-            ret = HTTP_FORBIDDEN;
+            ret = HTTP_TOO_MANY_REQUESTS;
             ntt_insert(hit_list, r->connection->client_ip, time(NULL), reason);
           } else {
 
@@ -229,7 +229,7 @@ static int access_checker(request_rec *r)
           /* If site is being hit too much, add to "hold" list and 403 */
           if (t-n->timestamp<site_interval && n->count>=site_count) {
             reason = 3;
-            ret = HTTP_FORBIDDEN;
+            ret = HTTP_TOO_MANY_REQUESTS;
             ntt_insert(hit_list, r->connection->client_ip, time(NULL), reason);
           } else {
 
@@ -246,7 +246,7 @@ static int access_checker(request_rec *r)
       }
 
       /* Perform email notification and system functions */
-      if (ret == HTTP_FORBIDDEN) {
+      if (ret == HTTP_TOO_MANY_REQUESTS) {
         char filename[1024];
         struct stat s;
         FILE *file;
@@ -286,13 +286,13 @@ static int access_checker(request_rec *r)
 
         } /* if (temp file does not exist) */
 
-      } /* if (ret == HTTP_FORBIDDEN) */
+      } /* if (ret == HTTP_TOO_MANY_REQUESTS) */
 
     } /* if (r->prev == NULL && r->main == NULL && hit_list != NULL) */
 
     /* END DoS Evasive Maneuvers Code */
 
-    if (ret == HTTP_FORBIDDEN
+    if (ret == HTTP_TOO_MANY_REQUESTS
 	&& (ap_satisfies(r) != SATISFY_ANY || !ap_some_auth_required(r))) {
         ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r,
             "client denied by server configuration: %s (reason: %s)",


### PR DESCRIPTION
It makes more sense to signalize a user that
he has sent too many requests instead of
403 - access forbidden.